### PR TITLE
[bugfix] ignore gitkeep on first model mapper

### DIFF
--- a/services/core/helper/index.js
+++ b/services/core/helper/index.js
@@ -19,6 +19,10 @@ const modelConfigTemplate = (model) => ({
   urls: [],
 });
 
+const isModel = (config) => { 
+  return config.model !== '.gitkeep'
+};
+
 const elasticsearchConfigTemplate = (modelsConfig) => `
 module.exports = ({ env }) => ({
   connection: {
@@ -49,7 +53,7 @@ module.exports = {
 
     models.map((model) => {
       const config = modelConfigTemplate(model);
-      modelsConfig.push(config);
+      if(isModel(config)) modelsConfig.push(config);
     });
 
     const elasticsearchConfig = elasticsearchConfigTemplate(modelsConfig);
@@ -57,6 +61,7 @@ module.exports = {
       if (err) throw err;
     });
   },
+  
   compareDataWithMap: ({ properties, docs }) => {
     // initial variable;
     const elasticSearchNumericTypes = [


### PR DESCRIPTION
Ignore gitkeep on creating models in config/elasticsearch.js 

![image](https://user-images.githubusercontent.com/63593982/117599211-c0b32300-b11f-11eb-855a-391345b5a16a.png)
